### PR TITLE
Update broken NHSTA URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 # nass
 
-Data from: http://www.nhtsa.gov/Data/National-Automotive-Sampling-System-(NASS)
+Data from: https://www.nhtsa.gov/research-data/national-automotive-sampling-system-nass
 
 In development: **Currently only CDS from 2015**
 
 ## Crashworthiness Data System (CDS)
-http://www.nhtsa.gov/Data/National-Automotive-Sampling-System-(NASS)/NASS-Crashworthiness-Data-System
+https://www.nhtsa.gov/national-automotive-sampling-system-nass/crashworthiness-data-system
 
 > NASS CDS has detailed data on a representative, random sample of thousands of minor, serious, and fatal crashes. Field research teams located at Primary Sampling Units (PSU's) across the country study about 5,000 crashes a year involving passenger cars, light trucks, vans, and utility vehicles. Trained crash investigators obtain data from crash sites, studying evidence such as skid marks, fluid spills, broken glass, and bent guard rails. They locate the vehicles involved, photograph them, measure the crash damage, and identify interior locations that were struck by the occupants. These researchers follow up on their on-site investigations by interviewing crash victims and reviewing medical records to determine the nature and severity of injuries.
 
 ## General Estimates System (GES)
-http://www.nhtsa.gov/Data/National-Automotive-Sampling-System-(NASS)/NASS-General-Estimates-System
+https://www.nhtsa.gov/national-automotive-sampling-system-nass/nass-general-estimates-system
 
 > In order for a crash to be eligible for the GES sample a police accident report (PAR) must be completed, it must involve at least one motor vehicle traveling on a traffic way, and the result must be property damage, injury, or death.
 >


### PR DESCRIPTION
Current URLs point to pages that no longer exist (the `/Data/` dir seems to be gone), updated to new NHSTA schema.